### PR TITLE
CSS Selector mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If we would like to manipulate HTML elements, first we have to **find** them by:
 
     >`var x = document.querySelectorAll("p.intro");`
 
-    (selecting all the `p` within the `class` "intro")
+    (selecting all the `p` with `class` "intro")
 
   * ## by HTML Object Collection 
     An HTMLCollection object is an array-like list of HTML elements.  


### PR DESCRIPTION
Notified by Wendy & Ben. 

line95: >`var x = document.querySelectorAll("p.intro");`
               (selecting all the 'p' WITHIN the 'class' "intro");  ==>  (selecting all the `p` with `class` "intro") 
as the selector implies P tags with the class(name) "intro"